### PR TITLE
build(arm32) install git for building arm32 package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ ENV DEBIAN_FRONTEND noninteractive
 
 RUN set -x \
 	&& apt-get update && apt-get install -y --no-install-recommends \
+		git \
 		ruby \
 		ruby-dev \
 		gcc \


### PR DESCRIPTION
this is required when running `make package-kong` in https://github.com/Kong/kong-build-tools
the following error is shown using the latest image (i.e. `kong/fpm:0.0.3`)
```
Step 25/27 : RUN /fpm-entrypoint.sh
 ---> Running in d96cb1ceb8bd
/var/lib/gems/2.3.0/gems/git-1.8.1/lib/git/lib.rb:1097:in `command': git '-c' 'color.ui=false' version   2>&1:sh: 1: git: not found (Git::GitExecuteError)
        from /var/lib/gems/2.3.0/gems/git-1.8.1/lib/git/lib.rb:990:in `current_command_version'
        from /var/lib/gems/2.3.0/gems/git-1.8.1/lib/git/lib.rb:1000:in `meets_required_version?'
        from /var/lib/gems/2.3.0/gems/git-1.8.1/lib/git.rb:28:in `<top (required)>'
        from /usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /var/lib/gems/2.3.0/gems/fpm-1.12.0/lib/fpm/package/gem.rb:7:in `<top (required)>'
        from /usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /var/lib/gems/2.3.0/gems/fpm-1.12.0/lib/fpm.rb:5:in `<top (required)>'
        from /usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /var/lib/gems/2.3.0/gems/fpm-1.12.0/bin/fpm:4:in `<top (required)>'
        from /usr/local/bin/fpm:23:in `load'
        from /usr/local/bin/fpm:23:in `<main>'
+ '[' deb == rpm ']'
```
which is caused by https://github.com/Kong/kong-build-tools/blob/0b08ed804065bf4620979c3cb29ceed20b5cc33c/dockerfiles/Dockerfile.package#L31

I've verified that using fpm image with git installed is able to successfully build package on my arm32 Pi4.