### PR TITLE
feat(gpg): install gpg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN set -x \
         ruby-ffi \
         rpm \
         git \
+        gpg \
     && apt-get install --reinstall -y bash \
     && gem install fpm \
     && mkdir /src/ \


### PR DESCRIPTION
some builds require gpg
```
+ gpg --import /kong.private.asc
/fpm-entrypoint.sh: line 74: gpg: command not found
```

https://internal.builds.konghq.com/blue/organizations/jenkins/kong/detail/chore%2Fci-arm-builds/19/pipeline/29/#step-64-log-1816