### PR TITLE
fix(rpm): re-add rpm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,11 @@ SHELL ["/bin/bash", "-e", "-x", "-c"]
 
 COPY patches/fpm-apk-archive-header.patch /tmp/fpm.patch
 
-RUN if [[ "$FPM_VERSION" == 'latest' ]]; then \
+RUN set -x \
+    && apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y --no-install-recommends rpm \
+    && if [[ "$FPM_VERSION" == 'latest' ]]; then \
         gem install --no-document fpm; \
     else \
         gem install --no-document fpm -v "$FPM_VERSION"; \


### PR DESCRIPTION
### Summary

Fixes:
```
#19 61.20 + /sign-rpm.exp /output/kong-enterprise-edition-3.2.0.0.aws.amd64.rpm
#19 61.21 spawn rpm --addsign /output/kong-enterprise-edition-3.2.0.0.aws.amd64.rpm
#19 61.21 couldn't execute "rpm": no such file or directory
#19 61.21     while executing
#19 61.21 "spawn rpm --addsign {*}$argv"
#19 61.21     (file "/sign-rpm.exp" line 5)
```

### Full changelog

* [Fix missing rpm package]