### PR TITLE
bump fpm to 1.15.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,4 @@ RUN cd $(gem env gemhome)/gems/fpm-* \
 
 WORKDIR /src/
 
-CMD /usr/local/bin/fpm
+CMD /usr/local/bundle/bin/fpm

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ RUN echo "disabled"
 
 FROM ruby:latest
 
-ARG FPM_VERSION=1.15.0
+ARG FPM_VERSION=1.15.1
 ENV FPM_VERSION="${FPM_VERSION}"
 
 ENV DEBIAN_FRONTEND noninteractive


### PR DESCRIPTION
### Summary

Use the latest version of fpm, which replaces deprecated methods `File.exists?` and `Dir.exists?`.
Also fix the path to fpm, which should be `/usr/local/bundle/bin/fpm`.

See https://github.com/jordansissel/fpm/pull/1981

### Issues resolved

Fix #90

### Testing

Not tested.

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes
